### PR TITLE
Adapt Dockerfile to symfony5

### DIFF
--- a/docker/httpd/Dockerfile
+++ b/docker/httpd/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update -y \
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && apt-get install -y nodejs
 
 RUN wget https://get.symfony.com/cli/installer -O - | bash
-#RUN mv /root/.symfony/bin/symfony /usr/local/bin/symfony
+RUN mv /root/.symfony5/bin/symfony /usr/local/bin/symfony
 
 COPY vhost.conf /opt/docker/etc/httpd/vhost.conf
 


### PR DESCRIPTION
### 1. Why is this change necessary?


### 2. What does this change do, exactly?
The name of the directory where symfony is extracted to did change when upgrading symfony. This changes the path in the Dockerfile from where it should be moved (and enables the line again).

### 3. Describe each step to reproduce the issue or behavior.


### 4. Please link to the relevant issues (if any).
https://opencaching-de.slack.com/archives/D01MXHDQC6P/p1660762403388279

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
